### PR TITLE
fix nested wrappers empty string

### DIFF
--- a/interpreter/dataswitches/wrapper/wrapper.go
+++ b/interpreter/dataswitches/wrapper/wrapper.go
@@ -2,6 +2,8 @@ package wrapperswicth
 
 import (
 	interpreter "gitlab.com/jbyte777/prompt-ql/core"
+	promptmsg "gitlab.com/jbyte777/prompt-ql/utils/promptmsg"
+	stringsutils "gitlab.com/jbyte777/prompt-ql/utils/strings"
 )
 
 func WrapperSwitch(
@@ -29,9 +31,15 @@ func WrapperSwitch(
 			err,
 		)
 	} else {
-		topCtx.InputChannels["data"] = append(
-			topCtx.InputChannels["data"],
-			data,
+		text := stringsutils.TrimWhitespace(
+			promptmsg.ReplacePromptMsgPrefix(data, ""),
 		)
+
+		if len(text) > 0 && text != " " {
+			topCtx.InputChannels["data"] = append(
+				topCtx.InputChannels["data"],
+				text,
+			)
+		}
 	}
 }

--- a/tests/basic-functionality/basic-function.go
+++ b/tests/basic-functionality/basic-function.go
@@ -7,7 +7,7 @@ import (
 	interpreter "gitlab.com/jbyte777/prompt-ql/interpreter"
 )
 
-// Works ++++
+// Works +++++
 func BasicFunctionTest(
 	openAiBaseUrl string,
 	openAiKey string,

--- a/tests/basic-functionality/basic-program.go
+++ b/tests/basic-functionality/basic-program.go
@@ -6,7 +6,7 @@ import (
 	interpreter "gitlab.com/jbyte777/prompt-ql/interpreter"
 )
 
-// Works ++++
+// Works +++++
 func BasicProgramTest(
 	openAiBaseUrl string,
 	openAiKey string,

--- a/tests/basic-functionality/nested-wrappers.go
+++ b/tests/basic-functionality/nested-wrappers.go
@@ -6,8 +6,8 @@ import (
 	interpreter "gitlab.com/jbyte777/prompt-ql/interpreter"
 )
 
-// Works ++++++?
-func BasicQueryTest(
+// Works +++
+func NestedWrappersTest(
 	openAiBaseUrl string,
 	openAiKey string,
 ) {
@@ -20,14 +20,9 @@ func BasicQueryTest(
 
 	result := interpreterInst.Instance.Execute(
 		`
-			{~open_query to="query1" model="gpt-3.5-turbo-16k"}
-				{~system}
-					You are a helpful and terse assistant.
-				{/system}
-				I want a response to the following question:
-				Write a comprehensive guide to machine learning
-			{/open_query}
-			{~listen_query from="query1" /}
+			{~data}
+				{~user}Example text{/user}
+			{/data}
 		`,
 		nil,
 	)
@@ -38,14 +33,9 @@ func BasicQueryTest(
 
 	fmt.Println("===================")
 	resultStr, _ := result.ResultDataStr()
-	errStr, _ := result.ResultErrorStr()
 	fmt.Printf(
-		"ChatGPT response:\n%v\n",
+		"ChatGPT response:\n%v",
 		resultStr,
-	)
-	fmt.Printf(
-		"ChatGPT error:\n%v\n",
-		errStr,
 	)
 	fmt.Println("===================")
 }

--- a/tests/basic-functionality/partial-execution.go
+++ b/tests/basic-functionality/partial-execution.go
@@ -8,7 +8,7 @@ import (
 	interpreter "gitlab.com/jbyte777/prompt-ql/interpreter"
 )
 
-// Works ++++
+// Works +++++
 func PartialExecutionTest(
 	openAiBaseUrl string,
 	openAiKey string,

--- a/tests/basic-functionality/query-with-wildcards.go
+++ b/tests/basic-functionality/query-with-wildcards.go
@@ -7,7 +7,7 @@ import (
 	interpreter "gitlab.com/jbyte777/prompt-ql/interpreter"
 )
 
-// Works ++++
+// Works +++++
 func QueryWithWildcardsTest(
 	openAiBaseUrl string,
 	openAiKey string,

--- a/tests/dialogues/simple-dialogue.go
+++ b/tests/dialogues/simple-dialogue.go
@@ -6,7 +6,7 @@ import (
 	interpreter "gitlab.com/jbyte777/prompt-ql/interpreter"
 )
 
-// Works ++++
+// Works +++++
 func SimpleDialogTest(
 	openAiBaseUrl string,
 	openAiKey string,


### PR DESCRIPTION
1. Fix bug with empty string while using nested wrappers like:

```
{~data}
  {~user}Example text{/user}
{/data}
```